### PR TITLE
Skip pytest if no test files are present

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -21,8 +21,13 @@ jobs:
         with:
           python-version: '3.11'
 
-      - name: Run pipeline tests
+      - name: Run Pytest if Tests Exist
         run: |
           cd pipeline
-          pip install -r requirements.txt
-          pytest . --maxfail=1
+          if find . -name "test_*.py" | grep .; then
+            echo "Test files found. Running pytest..."
+            pip install -r requirements.txt
+            pytest . --maxfail=1
+          else
+            echo "No test files found. Skipping pytest."
+          fi


### PR DESCRIPTION
Modified workflow to skip pytest if no test files are present in the pipeline folder. Makes it more robust and ensures no failed workflows simply from no test files. Closes #28 