### PR TITLE
Completed Terraform code for the Weekly Email Summary

### DIFF
--- a/pipeline/extract_steam.py
+++ b/pipeline/extract_steam.py
@@ -188,7 +188,7 @@ def fetch_platform_price(soup: BeautifulSoup) -> str:
     if not price:
         game_purchase_price = soup.find(class_="game_purchase_price")
         if game_purchase_price and "Free To Play" in game_purchase_price.text:
-            price = "Free To Play!"
+            price = "0"
 
     if not price:
         discount_price = soup.find(class_="discount_original_price")
@@ -298,6 +298,7 @@ def steam_handler(event, context):
         scroll_to_date = (datetime.now() - timedelta(1)).strftime("%d %b, %Y")
 
     data = scrape_newest(url, scroll_to_date)
+    print(data)
     return f"Completed {len(data)} entries"
 
 if __name__ == "__main__":

--- a/terraform/ETL_pipeline.tf
+++ b/terraform/ETL_pipeline.tf
@@ -247,7 +247,7 @@ resource "aws_iam_role" "report_scheduler_role" {
 
 # EventBridge Scheduler to run Step Function every day
 
-resource "aws_scheduler_schedule" "steam_etl_pipeline_schedule" {
+resource "aws_scheduler_schedule" "etl_pipeline_schedule" {
     name = "c15-play-stream-etl-pipeline-daily-trigger"
     schedule_expression   = "rate(1 day)"  # Runs every day
     flexible_time_window {

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -36,6 +36,6 @@ variable "DB_NAME" {
     type = string  
 }
 
-variable "ACCOUNT_NUMBER" {
+variable "ABDI_EMAIL" {
     type = string
 }

--- a/terraform/weekly_email_summary.tf
+++ b/terraform/weekly_email_summary.tf
@@ -1,0 +1,137 @@
+# ECR definition for the code that gets weekly email summaries
+
+data "aws_ecr_repository" "c15-play-stream-weekly-email-summary" {
+    name = "c15-play-stream-weekly-email-summary" 
+}
+
+data "aws_ecr_image" "weekly-summary-latest-image" {
+    repository_name = "c15-play-stream-weekly-email-summary"
+    most_recent     = true
+}
+
+# Setting the email addresses for the Weekly Summaries
+
+data "aws_ses_email_identity" "abdi_email" {
+  email = var.ABDI_EMAIL 
+}
+
+# Setting IAM information
+
+resource "aws_iam_policy" "send_email_policy" {
+  name        = "SES_SendEmailPolicy"
+  description = "Policy for sending emails using SES"
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = [
+          "ses:SendEmail",
+          "ses:SendRawEmail"
+        ]
+        Effect   = "Allow"
+        Resource = [data.aws_ses_email_identity.abdi_email.arn]
+      },
+    ]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "lambda-weekly-summary-policy-attachment" {
+  role       = aws_iam_role.lambda_task_role.name
+  policy_arn = aws_iam_policy.send_email_policy.arn
+}
+
+# Lambda Function to make the Weekly Email Summary work
+
+resource "aws_lambda_function" "c15-play-stream-weekly-summary-lambda-function" {
+    function_name = "c15-play-stream-weekly-email-summary-lambda-function"
+    package_type = "Image"
+    image_uri = data.aws_ecr_image.weekly-summary-latest-image.image_uri
+    memory_size   = 128
+    timeout       = 120
+    
+    environment {
+        variables = {
+        DB_HOST      = var.DB_HOST
+        DB_NAME      = var.DB_NAME
+        DB_PASSWORD  = var.DB_PASSWORD
+        DB_PORT      = var.DB_PORT
+        DB_USER      = var.DB_USERNAME
+        }
+    }
+
+    role = aws_iam_role.lambda_task_role.arn
+}
+
+# Making the Step Function to call the Weekly Email Summary Lambda Function
+
+resource "aws_sfn_state_machine" "weekly-email-summary-step-function" {
+    name     = "c15-play-stream-weekly-email-summary-step-function"
+    role_arn = aws_iam_role.lambda_task_role.arn
+    publish  = true
+    type     = "EXPRESS"
+
+    definition = jsonencode({
+        "Comment": "Step Function to run the Weekly Email Summary Lambda Function",
+        "StartAt": "Run Weekly Email Summary Lambda",
+        "States": {
+        "Run Weekly Email Summary Lambda": {
+            "Type": "Task",
+            "Resource": "arn:aws:states:::lambda:invoke",
+            "Parameters": {
+            "FunctionName": aws_lambda_function.c15-play-stream-weekly-summary-lambda-function.arn,
+            "Payload": {}
+            },
+            "ResultPath": "$.lambdaResult",
+            "Next": "Send Email Notification"
+        },
+        "SendEmail": {
+        "Type": "Task",
+        "Resource": "arn:aws:states:::aws-sdk:sesv2:sendEmail",
+        "Parameters": {
+          "Content": {
+            "Simple": {
+              "Body": {
+                "Html": {
+                  "Data.$": "$.Payload.body"
+                }
+              },
+              "Subject": {
+                "Data": "ALERT"
+              }
+            }
+          },
+          "Destination": {
+            "ToAddresses": ["${var.ABDI_EMAIL}"]
+          },
+          "FeedbackForwardingEmailAddress": "${var.ABDI_EMAIL}",
+          "FromEmailAddress": "${var.ABDI_EMAIL}"
+        },
+        "End": true
+        },
+        "EndState": {
+            "Type": "Succeed"
+        }
+        }
+    })
+
+    logging_configuration {
+        log_destination       = "${aws_cloudwatch_log_group.play-stream_state_machine_logs.arn}:*"
+        include_execution_data = true
+        level                 = "ALL"
+    }
+}
+
+# Making the EventBridge Scheduler to run this weekly
+
+resource "aws_scheduler_schedule" "weekly-email-summary-scheduler" {
+    name = "c15-play-stream-weekly-email-summary-scheduler"
+    schedule_expression   = "rate(1 week)"  # Runs every week
+    flexible_time_window {
+        mode = "OFF"
+    }
+    target {
+        arn      = aws_sfn_state_machine.weekly-email-summary-step-function.arn
+        role_arn = aws_iam_role.report_scheduler_role.arn
+    }
+}


### PR DESCRIPTION
I have completed Terraform Code for the Weekly Email Summary feature for our project

The AWS resources involved in this are the following:
- Getting the latest image from an ECR containing a dockerised version of a Weekly Summary Python Script
- Setting an email identity to send and receive the email (Using my own)
- Setting up IAM policies to allow emails to be sent
- Making the Lambda Function for the Weekly Summary code
- Setting up a Step Function to run the Lambda Function and then to send the output as an email to the designated user
- Making an EventBridge Scheduler to run this code every week

Closes ticket #61 