### PR TITLE
Rob steam extract

### DIFF
--- a/pipeline/steam_pipeline/steam_extract.py
+++ b/pipeline/steam_pipeline/steam_extract.py
@@ -279,7 +279,7 @@ def scrape_newest(url: str, target_date: str, local: bool, conn: psycopg.Connect
     # Configure to run local or run in cloud
     if local:
         options = webdriver.ChromeOptions()
-        options.add_argument("--headless")
+        # options.add_argument("--headless")
         driver = webdriver.Chrome(service=Service(
             ChromeDriverManager().install()), options=options)
     else:
@@ -303,7 +303,8 @@ def scrape_newest(url: str, target_date: str, local: bool, conn: psycopg.Connect
         driver.quit()
         for link in game_links:
             game_data = get_data(link)
-            print(game_data.get('title'))
+            if game_data.get('title') in current_games:
+                break
             logging.info('Processed %s', game_data.get('title'))
             page_data_list.append(game_data)
             progress.update(task, advance=1)

--- a/pipeline/steam_pipeline/steam_pipeline.py
+++ b/pipeline/steam_pipeline/steam_pipeline.py
@@ -80,7 +80,7 @@ def lambda_handler(event=None, context=None) -> None:
 
     # Extract
     url = "https://store.steampowered.com/search/?sort_by=Released_DESC&category1=998&supportedlang=english&ndl=1"
-    scraped_data = scrape_newest(url, target_date, local)
+    scraped_data = scrape_newest(url, target_date, local, db_connection)
 
     # Transform
     cleaned_data = clean_data(scraped_data)

--- a/pipeline/steam_pipeline/steam_pipeline.py
+++ b/pipeline/steam_pipeline/steam_pipeline.py
@@ -31,7 +31,7 @@ def init_args() -> tuple:
             type=str,
             required=False,
             help="Set a target date, in the form' 11 Feb, 2025'. Defaults to yesterday.")
-    
+
     args = parser.parse_args()
     return (args.local, args.target_date)
 
@@ -75,8 +75,8 @@ def lambda_handler(event=None, context=None) -> None:
     host = ENV["DB_HOST"]
     port = ENV["DB_PORT"]
     name = ENV["DB_NAME"]
-    CONN_STRING = f"""postgresql://{user}:{password}@{host}:{port}/{name}"""
-    db_connection = psycopg.connect(CONN_STRING, row_factory=dict_row)
+    conn_string = f"""postgresql://{user}:{password}@{host}:{port}/{name}"""
+    db_connection = psycopg.connect(conn_string, row_factory=dict_row)
 
     # Extract
     url = "https://store.steampowered.com/search/?sort_by=Released_DESC&category1=998&supportedlang=english&ndl=1"


### PR DESCRIPTION
I have added a condition to stop scraping games if the script starts to scrape games already in the database. This massively improves efficiency and reduces lambda cost.

Closes #118

CHANGES MADE
- Steam extract only scrapes new games
- Steam pipeline passes in the database connection to allow the extract to query the database for existing games.